### PR TITLE
Update ramsey library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ramsey/uuid": "2.8"
+        "ramsey/uuid": "3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
## What
- Update the library used to create cid

## Why
- The new unified php sentry sdk requires the ramsey/uuid library minimum version 3.3