### PR TITLE
Update ramsey uuid library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ramsey/uuid": "2.8"
+        "ramsey/uuid": "3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/lib/Buzz/Client/Cid.php
+++ b/lib/Buzz/Client/Cid.php
@@ -3,8 +3,8 @@
 namespace Buzz\Client;
 
 use Buzz\Message\RequestInterface;
-use Rhumsaa\Uuid\Uuid;
-use Rhumsaa\Uuid\Exception\UnsatisfiedDependencyException;
+use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
+use Ramsey\Uuid\Uuid;
 
 class Cid
 {


### PR DESCRIPTION
## What
- Update the library used to create cid

## Why
- The new unified php sentry sdk requires the ramsey/uuid library minimum version 3.3